### PR TITLE
Create a basic shell.nix for the current MSV of Rust

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+nix_direnv_watch_file shell.nix
+nix_direnv_watch_file rust-toolchain.toml
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.direnv
+.vscode

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,136 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689261696,
+        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-dev": {
+      "locked": {
+        "lastModified": 1689345409,
+        "narHash": "sha256-pM/3LZUoL7R68Xb15SUJ5F/zJBFuiZgDAXg5NdPvT+k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4774ffce45f6b9f1ec9b8ce636b6f4b85650e142",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1688049487,
+        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-dev": "nixpkgs-dev",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689302058,
+        "narHash": "sha256-yD74lcHTrw4niXcE9goJLbzsgyce48rQQoy5jK5ZK40=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7b8dbbf4c67ed05a9bf3d9e658c12d4108bc24c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "rust-libp2p development";
+
+  inputs.flake-parts.url = github:hercules-ci/flake-parts;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
+  inputs.nixpkgs-dev.url = github:NixOS/nixpkgs/master;
+  inputs.rust-overlay.url = github:oxalica/rust-overlay;
+
+  inputs.rust-overlay.inputs = {
+    nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-dev, flake-parts, rust-overlay, ... }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      perSystem = { config, self', inputs', system, ... }:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          pkgs-dev = import nixpkgs-dev {
+            inherit system overlays;
+          };
+        in
+        {
+          devShells.default = import ./shell.nix {
+            inherit pkgs pkgs-dev;
+          };
+        };
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      flake = {
+        overlays = [
+          rust-overlay.overlays
+        ];
+      };
+    };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.65"
+profile = "default"
+components = [ "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{ pkgs ? import <nixpkgs> { }
+, pkgs-dev
+, ...
+}:
+let
+  linuxPkgs = with pkgs; lib.optional stdenv.isLinux (
+    inotifyTools
+  );
+  macosPkgs = with pkgs; lib.optional stdenv.isDarwin (
+    with darwin.apple_sdk.frameworks; [
+      # macOS file watcher support
+      CoreFoundation
+      CoreServices
+    ]
+  );
+  devPkgs = with pkgs; [
+    ## rust
+    (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+
+    pkgs-dev.wasm-pack # v0.11.1
+    pkgs-dev.binaryen
+
+    # NodeJS
+    nodejs-18_x
+  ];
+in
+with pkgs;
+mkShell {
+  buildInputs = devPkgs;
+}


### PR DESCRIPTION
Rust 1.65 is used as the base MSV version.

## Description
The development environment for the rust-libp2p implementation for the nix shell was missing, this PR adds a basic setup based on the MSV of Rust specified by the rust-libp2p project.

## Notes & open questions
The setup utilizes two complementary pieces of technology:
1. `nix` is used to define and setup a development shell environment
2. `direnv` is used to automatically load the development environment from the project root

## Change checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
