### PR TITLE
feat(ping): Extend ping protocol library to be buildable for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "futures-timer",
+ "getrandom 0.2.10",
  "instant",
  "libp2p-core",
  "libp2p-identity",

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.43.0 
+## 0.43.1 - unreleased
+
+- Add support for the `wasm-bindgen` feature to Cargo.toml
+  See [PR 4258]
+
+[PR 4258]: https://github.com/libp2p/rust-libp2p/pull/4258
+
+## 0.43.0
 
 - Raise MSRV to 1.65.
   See [PR 3715].

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -10,10 +10,14 @@ repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
+[features]
+wasm-bindgen = ["futures-timer/wasm-bindgen", "getrandom/js", "instant/wasm-bindgen", "instant/inaccurate"]
+
 [dependencies]
 either = "1.9.0"
 futures = "0.3.28"
 futures-timer = "3.0.2"
+getrandom = "0.2"
 instant = "0.1.12"
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -44,6 +44,10 @@
 //!
 //! [`Swarm`]: libp2p_swarm::Swarm
 //! [`Transport`]: libp2p_core::Transport
+//! 
+//! # WASM support
+//! This module supports execution in a WASM environment. In order to build the module with WASM support, activate
+//! the **`wasm-bindgen` feature**.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 


### PR DESCRIPTION
## Description

The ping protocol did not support WASM natively, so this PR extends the Cargo.toml with a new feature `wasm-bindgen` that allows the `libp2p_ping` package and consequently the `ping` protocol implementation to be used in a `wasm-bindgen` environment.

## Notes & open questions

None

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
