### PR TITLE
feat: Add ability to configure custom socket options

### DIFF
--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.48.0
 
+- Add `Config::with_socket_config` to run a caller-supplied hook against every UDP socket
+  (both recv and send) before it is bound, e.g. to set `SO_MARK` for firewall/fwmark
+  classification. Re-export the `socket2` crate. Note: `Config` now has an additional
+  field, so constructing it with a full struct literal requires `..Default::default()`.
+
 - Remove `async_std` dependency [PR 5958](https://github.com/libp2p/rust-libp2p/pull/5958)
 
 <!-- Update to libp2p-swarm v0.47.0 -->

--- a/protocols/mdns/src/behaviour/iface.rs
+++ b/protocols/mdns/src/behaviour/iface.rs
@@ -123,12 +123,16 @@ where
         query_response_sender: mpsc::Sender<(PeerId, Multiaddr, Instant)>,
     ) -> io::Result<Self> {
         tracing::info!(address=%addr, "creating instance on iface address");
+        let socket_config = config.socket_config.clone();
         let recv_socket = match addr {
             IpAddr::V4(addr) => {
                 let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?;
                 socket.set_reuse_address(true)?;
                 #[cfg(unix)]
                 socket.set_reuse_port(true)?;
+                if let Some(socket_config) = &socket_config {
+                    (socket_config.0)(&socket)?;
+                }
                 socket.bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5353).into())?;
                 socket.set_multicast_loop_v4(true)?;
                 socket.set_multicast_ttl_v4(255)?;
@@ -140,6 +144,9 @@ where
                 socket.set_reuse_address(true)?;
                 #[cfg(unix)]
                 socket.set_reuse_port(true)?;
+                if let Some(socket_config) = &socket_config {
+                    (socket_config.0)(&socket)?;
+                }
                 socket.bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 5353).into())?;
                 socket.set_multicast_loop_v6(true)?;
                 // TODO: find interface matching addr.
@@ -157,7 +164,20 @@ where
                 SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
             }
         };
-        let send_socket = U::from_std(UdpSocket::bind(bind_addr)?)?;
+        // Build the send socket through `socket2` so the caller's socket hook (e.g.
+        // `SO_MARK`) is applied to outbound mDNS traffic as well.
+        let send_socket = {
+            let socket = Socket::new(
+                Domain::for_address(bind_addr),
+                Type::DGRAM,
+                Some(socket2::Protocol::UDP),
+            )?;
+            if let Some(socket_config) = &socket_config {
+                (socket_config.0)(&socket)?;
+            }
+            socket.bind(&bind_addr.into())?;
+            U::from_std(UdpSocket::from(socket))?
+        };
 
         // randomize timer to prevent all converging and firing at the same time.
         let query_interval = {

--- a/protocols/mdns/src/lib.rs
+++ b/protocols/mdns/src/lib.rs
@@ -35,7 +35,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use std::{
+    fmt, io,
     net::{Ipv4Addr, Ipv6Addr},
+    sync::Arc,
     time::Duration,
 };
 
@@ -43,6 +45,7 @@ mod behaviour;
 #[cfg(feature = "tokio")]
 pub use crate::behaviour::tokio;
 pub use crate::behaviour::{Behaviour, Event};
+pub use socket2;
 
 /// The DNS service name for all libp2p peers used to query for addresses.
 const SERVICE_NAME: &[u8] = b"_p2p._udp.local";
@@ -55,6 +58,23 @@ const META_QUERY_SERVICE_FQDN: &str = "_services._dns-sd._udp.local.";
 
 pub const IPV4_MDNS_MULTICAST_ADDRESS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 pub const IPV6_MDNS_MULTICAST_ADDRESS: Ipv6Addr = Ipv6Addr::new(0xFF02, 0, 0, 0, 0, 0, 0, 0xFB);
+
+/// Callback applied to every UDP socket the mDNS behaviour creates, allowing the caller to
+/// set arbitrary socket options (e.g. `SO_MARK`) before the socket is bound.
+pub(crate) type SocketConfigFn = Arc<dyn Fn(&socket2::Socket) -> io::Result<()> + Send + Sync>;
+
+/// Wrapper around a [`SocketConfigFn`] so that [`Config`] keeps deriving [`Clone`] and
+/// [`Debug`].
+///
+/// This type is opaque; construct it via [`Config::with_socket_config`].
+#[derive(Clone)]
+pub struct SocketConfig(pub(crate) SocketConfigFn);
+
+impl fmt::Debug for SocketConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SocketConfig(<fn>)")
+    }
+}
 
 /// Configuration for mDNS.
 #[derive(Debug, Clone)]
@@ -69,6 +89,10 @@ pub struct Config {
     pub query_interval: Duration,
     /// Use IPv6 instead of IPv4.
     pub enable_ipv6: bool,
+    /// Optional callback to customise UDP sockets before they are bound.
+    ///
+    /// This field is opaque; set it via [`Config::with_socket_config`].
+    pub socket_config: Option<SocketConfig>,
 }
 
 impl Default for Config {
@@ -77,6 +101,34 @@ impl Default for Config {
             ttl: Duration::from_secs(6 * 60),
             query_interval: Duration::from_secs(5 * 60),
             enable_ipv6: false,
+            socket_config: None,
         }
+    }
+}
+
+impl Config {
+    /// Registers a callback that is run against every UDP socket the mDNS behaviour
+    /// creates, *before* the socket is bound.
+    ///
+    /// This grants access to the underlying [`socket2::Socket`] so that arbitrary socket
+    /// options can be set. Returning an error aborts creation of that socket.
+    ///
+    /// A common use is tagging sockets with `SO_MARK` so that firewall rules can classify
+    /// or filter libp2p traffic via fwmark:
+    ///
+    /// ```no_run
+    /// # use libp2p_mdns::Config;
+    /// let config = Config::default().with_socket_config(|socket| {
+    ///     #[cfg(target_os = "linux")]
+    ///     socket.set_mark(0x1234)?;
+    ///     Ok(())
+    /// });
+    /// ```
+    pub fn with_socket_config(
+        mut self,
+        f: impl Fn(&socket2::Socket) -> io::Result<()> + Send + Sync + 'static,
+    ) -> Self {
+        self.socket_config = Some(SocketConfig(Arc::new(f)));
+        self
     }
 }

--- a/protocols/mdns/tests/use-tokio.rs
+++ b/protocols/mdns/tests/use-tokio.rs
@@ -48,6 +48,33 @@ async fn test_discovery_tokio_ipv6() {
 }
 
 #[tokio::test]
+async fn socket_config_hook_runs_tokio() {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let config = {
+        let counter = counter.clone();
+        Config::default().with_socket_config(move |_socket| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+    };
+
+    // Discovery can only succeed once the mDNS recv and send sockets have been created,
+    // which is exactly when the hook runs.
+    run_discovery_test(config).await;
+
+    assert!(counter.load(Ordering::SeqCst) > 0);
+}
+
+#[tokio::test]
 async fn test_expired_tokio() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.13.0
 
+- Add `Config::with_socket_config` to run a caller-supplied hook against every UDP socket
+  before it is bound, e.g. to set `SO_MARK` for firewall/fwmark classification. The hook
+  applies to dialer sockets as well as listeners. Re-export the `socket2` crate.
+
 - Remove `async-std` support.
   See [PR 5954](https://github.com/libp2p/rust-libp2p/pull/5954)
 

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -21,7 +21,7 @@ rustls = { version = "0.23.9", default-features = false }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["net", "rt", "time"], optional = true }
 tracing = { workspace = true }
-socket2 = "0.5.7"
+socket2 = { version = "0.5.7", features = ["all"] }
 ring = { workspace = true }
 
 [features]

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -18,12 +18,28 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::{sync::Arc, time::Duration};
+use std::{fmt, io, sync::Arc, time::Duration};
 
 use quinn::{
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
     MtuDiscoveryConfig, VarInt,
 };
+use socket2::Socket;
+
+/// Callback applied to every UDP socket the transport creates, allowing the caller to set
+/// arbitrary socket options (e.g. `SO_MARK`) before the socket is bound.
+pub(crate) type SocketConfigFn = Arc<dyn Fn(&Socket) -> io::Result<()> + Send + Sync>;
+
+/// Wrapper around a [`SocketConfigFn`] so that [`Config`] keeps deriving [`Clone`] and the
+/// transport keeps deriving [`Debug`].
+#[derive(Clone)]
+pub(crate) struct SocketConfig(pub(crate) SocketConfigFn);
+
+impl fmt::Debug for SocketConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SocketConfig(<fn>)")
+    }
+}
 
 /// Config for the transport.
 #[derive(Clone)]
@@ -71,6 +87,9 @@ pub struct Config {
 
     /// Parameters governing MTU discovery. See [`MtuDiscoveryConfig`] for details.
     mtu_discovery_config: Option<MtuDiscoveryConfig>,
+
+    /// Optional callback to customise UDP sockets before they are bound.
+    pub(crate) socket_config: Option<SocketConfig>,
 }
 
 #[expect(deprecated)]
@@ -98,6 +117,7 @@ impl Config {
             max_stream_data: 10_000_000,
             keypair: keypair.clone(),
             mtu_discovery_config: Some(Default::default()),
+            socket_config: None,
         }
     }
 
@@ -112,6 +132,33 @@ impl Config {
     /// Disable MTU path discovery (it is enabled by default).
     pub fn disable_path_mtu_discovery(mut self) -> Self {
         self.mtu_discovery_config = None;
+        self
+    }
+
+    /// Registers a callback that is run against every UDP socket the transport creates,
+    /// for both listeners and dialers, *before* the socket is bound.
+    ///
+    /// This grants access to the underlying [`socket2::Socket`] so that arbitrary socket
+    /// options can be set. Returning an error aborts the corresponding listen or dial.
+    ///
+    /// A common use is tagging sockets with `SO_MARK` so that firewall rules can classify
+    /// or filter libp2p traffic via fwmark:
+    ///
+    /// ```no_run
+    /// # use libp2p_quic as quic;
+    /// # fn config(keypair: &libp2p_identity::Keypair) -> quic::Config {
+    /// quic::Config::new(keypair).with_socket_config(|socket| {
+    ///     #[cfg(target_os = "linux")]
+    ///     socket.set_mark(0x1234)?;
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    pub fn with_socket_config(
+        mut self,
+        f: impl Fn(&Socket) -> io::Result<()> + Send + Sync + 'static,
+    ) -> Self {
+        self.socket_config = Some(SocketConfig(Arc::new(f)));
         self
     }
 }
@@ -139,6 +186,8 @@ impl From<Config> for QuinnConfig {
             handshake_timeout: _,
             keypair,
             mtu_discovery_config,
+            // Consumed by `GenTransport::new`, not relevant to the quinn config.
+            socket_config: _,
         } = config;
         let mut transport = quinn::TransportConfig::default();
         // Disable uni-directional streams.

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -73,6 +73,7 @@ pub use connection::{Connecting, Connection, Stream};
 #[cfg(feature = "tokio")]
 pub use provider::tokio;
 pub use provider::Provider;
+pub use socket2;
 pub use transport::GenTransport;
 
 /// Errors that may happen on the [`GenTransport`] or a single [`Connection`].

--- a/transports/quic/src/transport.rs
+++ b/transports/quic/src/transport.rs
@@ -49,7 +49,7 @@ use libp2p_identity::PeerId;
 use socket2::{Domain, Socket, Type};
 
 use crate::{
-    config::{Config, QuinnConfig},
+    config::{Config, QuinnConfig, SocketConfig},
     hole_punching::hole_puncher,
     provider::Provider,
     ConnectError, Connecting, Connection, Error,
@@ -80,6 +80,8 @@ pub struct GenTransport<P: Provider> {
     dialer: HashMap<SocketFamily, quinn::Endpoint>,
     /// Waker to poll the transport again when a new dialer or listener is added.
     waker: Option<Waker>,
+    /// Optional callback to customise UDP sockets before they are bound.
+    socket_config: Option<SocketConfig>,
     /// Holepunching attempts
     hole_punch_attempts: HashMap<SocketAddr, oneshot::Sender<Connecting>>,
 }
@@ -90,6 +92,7 @@ impl<P: Provider> GenTransport<P> {
     pub fn new(config: Config) -> Self {
         let handshake_timeout = config.handshake_timeout;
         let support_draft_29 = config.support_draft_29;
+        let socket_config = config.socket_config.clone();
         let quinn_config = config.into();
         Self {
             listeners: SelectAll::new(),
@@ -98,6 +101,7 @@ impl<P: Provider> GenTransport<P> {
             dialer: HashMap::new(),
             waker: None,
             support_draft_29,
+            socket_config,
             hole_punch_attempts: Default::default(),
         }
     }
@@ -190,6 +194,12 @@ impl<P: Provider> GenTransport<P> {
             socket.set_only_v6(true)?;
         }
 
+        // Run the caller-supplied hook before binding so that options such as `SO_MARK`
+        // take effect for this socket.
+        if let Some(socket_config) = &self.socket_config {
+            (socket_config.0)(&socket)?;
+        }
+
         socket.bind(&socket_addr.into())?;
 
         Ok(socket.into())
@@ -204,7 +214,9 @@ impl<P: Provider> GenTransport<P> {
             SocketFamily::Ipv4 => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
             SocketFamily::Ipv6 => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
         };
-        let socket = UdpSocket::bind(listen_socket_addr)?;
+        // Build the dialer socket through `create_socket` so the caller's socket hook
+        // (e.g. `SO_MARK`) is applied to outbound sockets as well as listeners.
+        let socket = self.create_socket(listen_socket_addr)?;
         let endpoint_config = self.quinn_config.endpoint_config.clone();
         let endpoint = Self::new_endpoint(endpoint_config, None, socket)?;
         Ok(endpoint)

--- a/transports/quic/tests/smoke.rs
+++ b/transports/quic/tests/smoke.rs
@@ -85,6 +85,58 @@ async fn ipv4_dial_ipv6() {
     assert_eq!(b_connected, a_peer_id);
 }
 
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn socket_config_hook_runs_for_listener_and_dialer() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let make_transport = |counter: Arc<AtomicUsize>| {
+        let keypair = generate_tls_keypair();
+        let peer_id = keypair.public().to_peer_id();
+        let config = quic::Config::new(&keypair).with_socket_config(move |_socket| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+        let transport = quic::GenTransport::<quic::tokio::Provider>::new(config)
+            .map(|(p, c), _| (p, StreamMuxerBox::new(c)))
+            .boxed();
+        (peer_id, transport)
+    };
+
+    let (_, mut listener) = make_transport(counter.clone());
+    let (_, mut dialer) = make_transport(counter.clone());
+
+    let addr = start_listening(&mut listener, "/ip4/127.0.0.1/udp/0/quic-v1").await;
+    connect(&mut listener, &mut dialer, addr).await;
+
+    // The hook must have run at least once for the listener socket and once for the
+    // dialer socket (the refactored `bound_socket` path).
+    assert!(counter.load(Ordering::SeqCst) >= 2);
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn socket_config_hook_error_aborts_listen() {
+    let keypair = generate_tls_keypair();
+    let config = quic::Config::new(&keypair)
+        .with_socket_config(|_socket| Err(io::Error::other("socket config hook failed")));
+    let mut transport = quic::GenTransport::<quic::tokio::Provider>::new(config)
+        .map(|(p, c), _| (p, StreamMuxerBox::new(c)))
+        .boxed();
+
+    let result = transport.listen_on(
+        ListenerId::next(),
+        "/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap(),
+    );
+    assert!(result.is_err());
+}
+
 /// Tests that a [`Transport::dial`] wakes up the task previously polling [`Transport::poll`].
 ///
 /// See https://github.com/libp2p/rust-libp2p/pull/3306 for context.

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.44.0
 
+- Add `Config::with_socket_config` to run a caller-supplied hook against every socket
+  (listeners and dialers) before it is bound or connected, e.g. to set `SO_MARK` for
+  firewall/fwmark classification. Re-export the `socket2` crate.
+
 - Remove `async-std` support.
   See [PR 5955](https://github.com/libp2p/rust-libp2p/pull/5955)
 

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -32,7 +32,7 @@ mod provider;
 
 use std::{
     collections::{HashSet, VecDeque},
-    io,
+    fmt, io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener},
     pin::Pin,
     sync::{Arc, RwLock},
@@ -50,7 +50,23 @@ use libp2p_core::{
 #[cfg(feature = "tokio")]
 pub use provider::tokio;
 use provider::{Incoming, Provider};
+pub use socket2;
 use socket2::{Domain, Socket, Type};
+
+/// Callback applied to every socket this transport creates, allowing the caller to set
+/// arbitrary socket options (e.g. `SO_MARK`) before the socket is bound or connected.
+type SocketConfigFn = Arc<dyn Fn(&Socket) -> io::Result<()> + Send + Sync>;
+
+/// Wrapper around a [`SocketConfigFn`] so that [`Config`] keeps deriving [`Clone`] and
+/// [`Debug`].
+#[derive(Clone)]
+struct SocketConfig(SocketConfigFn);
+
+impl fmt::Debug for SocketConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SocketConfig(<fn>)")
+    }
+}
 
 /// The configuration for a TCP/IP transport capability for libp2p.
 #[derive(Clone, Debug)]
@@ -61,6 +77,8 @@ pub struct Config {
     nodelay: bool,
     /// Size of the listen backlog for listen sockets.
     backlog: u32,
+    /// Optional callback to customise sockets before they are bound/connected.
+    socket_config: Option<SocketConfig>,
 }
 
 type Port = u16;
@@ -138,6 +156,7 @@ impl Config {
             ttl: None,
             nodelay: true, // Disable Nagle's algorithm by default.
             backlog: 1024,
+            socket_config: None,
         }
     }
 
@@ -156,6 +175,32 @@ impl Config {
     /// Configures the listen backlog for new listen sockets.
     pub fn listen_backlog(mut self, backlog: u32) -> Self {
         self.backlog = backlog;
+        self
+    }
+
+    /// Registers a callback that is run against every socket this transport creates,
+    /// for both listeners and dialers, after libp2p's own options have been applied and
+    /// *before* the socket is bound or connected.
+    ///
+    /// This grants access to the underlying [`socket2::Socket`] so that arbitrary socket
+    /// options can be set. Returning an error aborts the corresponding listen or dial.
+    ///
+    /// A common use is tagging sockets with `SO_MARK` so that firewall rules can classify
+    /// or filter libp2p traffic via fwmark:
+    ///
+    /// ```no_run
+    /// # use libp2p_tcp as tcp;
+    /// let config = tcp::Config::default().with_socket_config(|socket| {
+    ///     #[cfg(target_os = "linux")]
+    ///     socket.set_mark(0x1234)?;
+    ///     Ok(())
+    /// });
+    /// ```
+    pub fn with_socket_config(
+        mut self,
+        f: impl Fn(&Socket) -> io::Result<()> + Send + Sync + 'static,
+    ) -> Self {
+        self.socket_config = Some(SocketConfig(Arc::new(f)));
         self
     }
 
@@ -207,6 +252,11 @@ impl Config {
         let _ = port_use; // silence the unused warning on non-unix platforms (i.e. Windows)
 
         socket.set_nonblocking(true)?;
+
+        // Run the caller-supplied hook last so it can also override the defaults set above.
+        if let Some(socket_config) = &self.socket_config {
+            (socket_config.0)(&socket)?;
+        }
 
         Ok(socket)
     }
@@ -820,6 +870,98 @@ mod tests {
 
         test("/ip4/127.0.0.1/tcp/0".parse().unwrap());
         test("/ip6/::1/tcp/0".parse().unwrap());
+    }
+
+    #[test]
+    fn socket_config_hook_runs_for_listener_and_dialer() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        async fn listener<T: Provider>(
+            config: Config,
+            addr: Multiaddr,
+            mut ready_tx: mpsc::Sender<Multiaddr>,
+        ) {
+            let mut tcp = Transport::<T>::new(config).boxed();
+            tcp.listen_on(ListenerId::next(), addr).unwrap();
+            loop {
+                match tcp.select_next_some().await {
+                    TransportEvent::NewAddress { listen_addr, .. } => {
+                        ready_tx.send(listen_addr).await.unwrap();
+                    }
+                    TransportEvent::Incoming { upgrade, .. } => {
+                        upgrade.await.unwrap();
+                        return;
+                    }
+                    e => panic!("Unexpected transport event: {e:?}"),
+                }
+            }
+        }
+
+        async fn dialer<T: Provider>(config: Config, mut ready_rx: mpsc::Receiver<Multiaddr>) {
+            let addr = ready_rx.next().await.unwrap();
+            let mut tcp = Transport::<T>::new(config);
+            tcp.dial(
+                addr,
+                DialOpts {
+                    role: Endpoint::Dialer,
+                    port_use: PortUse::New,
+                },
+            )
+            .unwrap()
+            .await
+            .unwrap();
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let make_config = || {
+            let counter = counter.clone();
+            Config::default().with_socket_config(move |_socket| {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        };
+
+        let (ready_tx, ready_rx) = mpsc::channel(1);
+        let listener = listener::<tokio::Tcp>(
+            make_config(),
+            "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+            ready_tx,
+        );
+        let dialer = dialer::<tokio::Tcp>(make_config(), ready_rx);
+        let rt = ::tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        let tasks = ::tokio::task::LocalSet::new();
+        let listener = tasks.spawn_local(listener);
+        tasks.block_on(&rt, dialer);
+        tasks.block_on(&rt, listener).unwrap();
+
+        // The hook must have run at least once for the listener socket and once for the
+        // dialer socket.
+        assert!(counter.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[test]
+    fn socket_config_hook_error_aborts_listen_and_dial() {
+        fn boom() -> Config {
+            Config::default()
+                .with_socket_config(|_socket| Err(io::Error::other("socket config hook failed")))
+        }
+
+        let mut tcp = Transport::<tokio::Tcp>::new(boom());
+        let listen_result =
+            tcp.listen_on(ListenerId::next(), "/ip4/127.0.0.1/tcp/0".parse().unwrap());
+        assert!(matches!(listen_result, Err(TransportError::Other(_))));
+
+        let dial_result = tcp.dial(
+            "/ip4/127.0.0.1/tcp/12345".parse().unwrap(),
+            DialOpts {
+                role: Endpoint::Dialer,
+                port_use: PortUse::New,
+            },
+        );
+        assert!(matches!(dial_result, Err(TransportError::Other(_))));
     }
 
     #[test]


### PR DESCRIPTION
Allow clients to configure TCP/UDP sockets used by libp2p through a new callback. This enables a client to use `set_mark` to tag libp2p traffic on Linux for easier filtering in a firewall.

This is an alternative, more generic, approach to the socket_mark.